### PR TITLE
now gulp.watch does not ruin prod build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ const pages = [
   {name: 'section', path: '_includes/section.njk'},
   {name: 'sections', path: '_includes/sections.njk'},
   {name: 'home', path: '_includes/home.njk'},
+  {name: '404', path: '_includes/404.njk'},
 ];
 
 const deviceTypes = {
@@ -65,7 +66,7 @@ function css(src, dest, fileName) {
     .pipe(gulp.dest(dest));
 }
 
-const build = () => {
+const build = cb => {
   del.sync(['_site/assets/styles/**']);
   css(globalStyles, `assets/styles/`, `common.css`);
   const pages = Object.keys(includedCss);
@@ -73,9 +74,11 @@ const build = () => {
       css(includedCss[page][deviceTypes.mobile], `assets/styles/${deviceTypes.mobile}/`, `${page}.css`);
       css(includedCss[page][deviceTypes.desktop], `assets/styles/${deviceTypes.desktop}/`, `${page}.css`);
     });
+  cb();
 }
 
-gulp.watch('./_includes/components/**/*.css', build);
+const watch = () =>
+  gulp.watch('./_includes/components/**/*.css', build);
 
-exports.watch = gulp.watch;
+exports.watch = watch;
 exports.default = build;

--- a/package.json
+++ b/package.json
@@ -6,20 +6,21 @@
   "author": "Valerii Diachenko",
   "scripts": {
     "dev": "concurrently \"gulp --watch\" \"eleventy --serve\"",
+    "prod": "gulp && eleventy",
     "debug": "set DEBUG=Eleventy*&&eleventy"
   },
   "devDependencies": {
     "@11ty/eleventy": "0.8.2",
     "@11ty/eleventy-plugin-syntaxhighlight": "2.0.3",
     "concurrently": "4.1.0",
+    "del": "4.1.1",
     "gulp": "4.0.2",
     "gulp-clean-css": "4.2.0",
     "gulp-concat": "2.6.1",
     "html-minifier": "4.0.0",
     "markdown-it": "8.4.2",
     "markdown-it-anchor": "5.0.2",
-    "markdown-it-emoji": "1.4.0",
-    "del": "4.1.1"
+    "markdown-it-emoji": "1.4.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
moved gulp.watch inside a task so it does not ruin separate builds anymore